### PR TITLE
Use size name for bstbox_read_line parameter

### DIFF
--- a/tools/include/bstbox_input.h
+++ b/tools/include/bstbox_input.h
@@ -4,6 +4,6 @@
 #include <stdio.h>
 
 int* bstbox_read_ints(char* input, size_t *size);
-char* bstbox_read_line(FILE* file, size_t* len);
+char* bstbox_read_line(FILE* file, size_t* size);
 
 #endif

--- a/tools/source/bstbox_input.c
+++ b/tools/source/bstbox_input.c
@@ -80,11 +80,11 @@ int* bstbox_read_ints(char* input, size_t *size) {
 /**
  * @brief Read a line from a file, dynamically allocating memory for the line.
  * @param file Input file stream.
- * @param len Pointer to store the length of the line read.
+ * @param size Pointer to store the length of the line read.
  * @return Dynamically allocated string containing the line, or NULL on failure.
  */
 char* bstbox_read_line(FILE* file, size_t* size) {
-    if (!file) {
+    if (!file || !size) {
         return NULL;
     }
 
@@ -112,7 +112,7 @@ char* bstbox_read_line(FILE* file, size_t* size) {
         }
     }
 
-    if (size == 0 && ch == EOF) {
+    if (*size == 0 && ch == EOF) {
         free(buffer);
         return NULL;
     }


### PR DESCRIPTION
## Summary
- rename bstbox_read_line parameter from len to size in header and implementation
- guard against null length pointer and fix EOF size check

## Testing
- `./test.sh` *(fails: fatal error: gtest/gtest.h: No such file or directory)*
- `apt-get update` *(403 Forbidden; repository not signed)*
- `apt-get install -y libgtest-dev` *(Unable to locate package libgtest-dev)*

------
https://chatgpt.com/codex/tasks/task_e_68b859e4341c83209d004a8b450ef2b9